### PR TITLE
Handle tenant/user API responses that are missing metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning].
 ## [Unreleased] <!-- #release:date -->
 
 * Imbue `Error` and `ApiError` with an `std::error::Error` implementation.
+* Handle API responses that do not include the `metadata` field in `Tenant`,
+  `User`, and `CreatedUser` responses.
 
 ## 0.1.0 - 2022-12-18
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# Maintainer instructions
+
+## Releasing a new version
+
+```
+cargo install cargo-release
+cargo release
+cargo release -x
+```

--- a/src/client/tenants.rs
+++ b/src/client/tenants.rs
@@ -47,6 +47,7 @@ pub struct Tenant {
     /// The name of the tenant.
     pub name: String,
     /// Arbitrary metadata that is attached to the tenant.
+    #[serde(default = "crate::serde::empty_json_object")]
     #[serde(with = "crate::serde::nested_json")]
     pub metadata: serde_json::Value,
     /// The time at which the tenant was created.

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -89,6 +89,7 @@ pub struct CreatedUser {
     /// The email for the user.
     pub email: String,
     /// Arbitrary metadata that is attached to the user.
+    #[serde(default = "crate::serde::empty_json_object")]
     #[serde(with = "crate::serde::nested_json")]
     pub metadata: serde_json::Value,
     /// The roles to which this user belongs.
@@ -111,6 +112,7 @@ pub struct User {
     /// The email for the user.
     pub email: String,
     /// Arbitrary metadata that is attached to the user.
+    #[serde(default = "crate::serde::empty_json_object")]
     #[serde(with = "crate::serde::nested_json")]
     pub metadata: serde_json::Value,
     /// The tenants to which this user belongs.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -82,3 +82,7 @@ pub mod nested_json {
         deserializer.deserialize_any(NestedJson)
     }
 }
+
+pub fn empty_json_object() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}


### PR DESCRIPTION
In some cases Frontegg does not return the `metadata` field in its
tenant and user API responses. Synthesize an empty object in these
cases, to match what the web UI does.