### PR TITLE
add necessary structs to support webhook user events

### DIFF
--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -126,7 +126,7 @@ pub struct WebhookUser {
     pub activated_for_tenant: Option<bool>,
     /// The locked status of the user.
     pub is_locked: Option<bool>,
-    /// The enttity managing the user.
+    /// The entity managing the user.
     pub managed_by: String,
     /// The mfa enrollment status of the user.
     pub mfa_enrolled: bool,
@@ -142,9 +142,9 @@ pub struct WebhookUser {
     pub sub: Uuid,
     /// The ID of the tenant of the user.
     pub tenant_id: Uuid,
-    /// The IDs of all tenants for the user.
+    /// The IDs of all tenants for the user. Missing on frontegg.user.disabledMFA events.
     pub tenant_ids: Option<Vec<Uuid>>,
-    /// The tenants to which this user belongs.
+    /// The tenants to which this user belongs. Missing on frontegg.user.disabledMFA events.
     pub tenants: Option<Vec<WebhookTenantBinding>>,
     /// The verified status of the user.
     pub verified: Option<bool>,
@@ -179,7 +179,7 @@ pub struct User {
 pub struct WebhookTenantBinding {
     /// The ID of the tenant.
     pub tenant_id: Uuid,
-    /// The roles to which the user belongs in this tenant.
+    /// The roles to which the user belongs in this tenant. Missing on frontegg.user.enrolledMFA events.
     pub roles: Option<Vec<Role>>,
 }
 

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -101,6 +101,55 @@ pub struct CreatedUser {
     pub created_at: OffsetDateTime,
 }
 
+/// The subset of a [`User`] returned by a webhook `frontegg.user.*` event
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookUser {
+    /// The ID of the user.
+    pub id: Uuid,
+    /// The name of the user.
+    pub name: Option<String>,
+    /// The email for the user.
+    pub email: String,
+    /// Arbitrary metadata that is attached to the user.
+    #[serde(default = "crate::serde::empty_json_object")]
+    #[serde(with = "crate::serde::nested_json")]
+    pub metadata: serde_json::Value,
+    /// The roles to which this user belongs.
+    pub roles: Vec<Role>,
+    /// The permissions which this user holds.
+    pub permissions: Vec<Permission>,
+    /// The time at which the user was created.
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    /// The activation status of the user for the tenant.
+    pub activated_for_tenant: Option<bool>,
+    /// The locked status of the user.
+    pub is_locked: Option<bool>,
+    /// The enttity managing the user.
+    pub managed_by: String,
+    /// The mfa enrollment status of the user.
+    pub mfa_enrolled: bool,
+    /// The mfa bypass status of the user.
+    pub mfa_bypass: Option<bool>,
+    /// The phone_number of the user.
+    pub phone_number: Option<String>,
+    /// The profile picture url of the user.
+    pub profile_picture_url: Option<String>,
+    /// The provider of the user.
+    pub provider: String,
+    /// The sub of the user.
+    pub sub: Uuid,
+    /// The ID of the tenant of the user.
+    pub tenant_id: Uuid,
+    /// The IDs of all tenants for the user.
+    pub tenant_ids: Option<Vec<Uuid>>,
+    /// The tenants to which this user belongs.
+    pub tenants: Option<Vec<WebhookTenantBinding>>,
+    /// The verified status of the user.
+    pub verified: Option<bool>,
+}
+
 /// A Frontegg user.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,6 +169,18 @@ pub struct User {
     /// The time at which the user was created.
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
+}
+
+/// Binds a [`User`] to a [`Tenant`] for webhook `frontegg.user.*` events
+///
+/// [`Tenant`]: crate::client::tenant::Tenant
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookTenantBinding {
+    /// The ID of the tenant.
+    pub tenant_id: Uuid,
+    /// The roles to which the user belongs in this tenant.
+    pub roles: Option<Vec<Role>>,
 }
 
 /// Binds a [`User`] to a [`Tenant`].

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -101,7 +101,7 @@ pub struct CreatedUser {
     pub created_at: OffsetDateTime,
 }
 
-/// The subset of a [`User`] returned by a webhook `frontegg.user.*` event
+/// The subset of a [`User`] returned by a `frontegg.user.*` webhook event
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookUser {
@@ -171,7 +171,7 @@ pub struct User {
     pub created_at: OffsetDateTime,
 }
 
-/// Binds a [`User`] to a [`Tenant`] for webhook `frontegg.user.*` events
+/// Binds a [`User`] to a [`Tenant`] for a `frontegg.user.*` webhook event
 ///
 /// [`Tenant`]: crate::client::tenant::Tenant
 #[derive(Debug, Clone, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ mod util;
 
 pub use client::roles::{Permission, Role};
 pub use client::tenants::{Tenant, TenantRequest};
-pub use client::users::{CreatedUser, User, UserListConfig, UserRequest};
+pub use client::users::{CreatedUser, User, UserListConfig, UserRequest, WebhookUser};
 pub use client::Client;
 pub use config::{ClientBuilder, ClientConfig};
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@ mod util;
 
 pub use client::roles::{Permission, Role};
 pub use client::tenants::{Tenant, TenantRequest};
-pub use client::users::{CreatedUser, User, UserListConfig, UserRequest, WebhookUser};
+pub use client::users::{
+    CreatedUser, User, UserListConfig, UserRequest, WebhookTenantBinding, WebhookUser,
+};
 pub use client::Client;
 pub use config::{ClientBuilder, ClientConfig};
 pub use error::Error;


### PR DESCRIPTION
## Summary
The `user` object returned by `frontegg.user.*` webhook events differs from the `User` structs in this package. This PR adds new `WebhookUser` and `WebhookTenantBinding` structs for Deserialization.

## Details
The new structs were tested against an axum server webhook route handler using JSON extractors. Saved event payloads for the following events were used for testing:

* frontegg.user.activated
* frontegg.user.authenticated
* frontegg.user.created
* frontegg.user.deleted
* frontegg.user.disabledMFA
* frontegg.user.enrolledMFA
* frontegg.user.invitedToTenant
* frontegg.user.removedFromTenant
* frontegg.user.signedUp
* frontegg.user.created
* frontegg.user.updated