### PR TITLE
ensure list of tenants ordered by name for tests

### DIFF
--- a/src/client/tenants.rs
+++ b/src/client/tenants.rs
@@ -63,6 +63,8 @@ pub struct Tenant {
 
 impl Client {
     /// Lists all tenants in the workspace.
+    ///
+    /// The returned vector is sorted by tenant ID.
     pub async fn list_tenants(&self) -> Result<Vec<Tenant>, Error> {
         let req = self.build_request(Method::GET, TENANT_PATH);
         let res = self.send_request(req).await?;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -71,7 +71,6 @@ async fn test_tenants_and_users() {
             metadata: json!({
                 "tenant_number": 1,
             }),
-            ..Default::default()
         })
         .await
         .unwrap();
@@ -80,13 +79,14 @@ async fn test_tenants_and_users() {
             id: tenant_id_2,
             name: "test tenant 2",
             metadata: json!(42),
-            ..Default::default()
         })
         .await
         .unwrap();
 
     // Verify tenant properties.
-    let tenants = client.list_tenants().await.unwrap();
+    let mut tenants = client.list_tenants().await.unwrap();
+    // Sort tenants by name to match order. Default ordering is by tenant ID.
+    tenants.sort_by(|a, b| a.name.cmp(&b.name));
     assert_eq!(tenants.len(), 2);
     assert_eq!(tenants[0].id, tenant_id_1);
     assert_eq!(tenants[1].id, tenant_id_2);
@@ -106,8 +106,8 @@ async fn test_tenants_and_users() {
             let created_user = client
                 .create_user(&UserRequest {
                     tenant_id: tenant.id,
-                    name: &*name,
-                    email: &*email,
+                    name: &name,
+                    email: &email,
                     skip_invite_email: true,
                     ..Default::default()
                 })


### PR DESCRIPTION
## Summary
This PR fixes the intermittent test errors for `test_tenants_and_users`. The ordering of tenants is now sorted by `name` in the test before assertions are made and users created for tenants.

## Details
The FrontEgg endpoint `https://api.frontegg.com/tenants/resources/tenants/v1` returns the list of tenants ordered by `tenantId`. The list of tenants would sometimes return an ordering like the below:

```json
[
  {
    "tenantId": "axxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "name": "test tenant 2",
    "id": "7xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "createdAt": "2023-02-17T20:48:59.673Z"
  },
  {
    "tenantId": "bxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "name": "test tenant 1",
    "id": "2xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    "createdAt": "2023-02-17T20:48:59.486Z"
  }
]
```  