### PR TITLE
Add support for getting a tenant by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Support getting a tenant by ID.
+
 ## [0.2.0] - 2023-02-18
 
 * Add the `WebhookUser` and `WebhookTenantBinding` to represent the user object

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,4 +48,4 @@ pub use client::users::{
 };
 pub use client::Client;
 pub use config::{ClientBuilder, ClientConfig};
-pub use error::Error;
+pub use error::{ApiError, Error};

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -42,6 +42,8 @@ pub static CLIENT_ID: Lazy<String> =
 pub static SECRET_KEY: Lazy<String> =
     Lazy::new(|| env::var("FRONTEGG_SECRET_KEY").expect("missing FRONTEGG_SECRET_KEY"));
 
+const TENANT_NAME_PREFIX: &str = "test tenant";
+
 fn new_client() -> Client {
     Client::new(ClientConfig {
         client_id: CLIENT_ID.clone(),
@@ -51,8 +53,10 @@ fn new_client() -> Client {
 
 async fn delete_existing_tenants(client: &Client) {
     for tenant in client.list_tenants().await.unwrap() {
-        info!(%tenant.id, "deleting existing tenant");
-        client.delete_tenant(tenant.id).await.unwrap();
+        if tenant.name.starts_with(TENANT_NAME_PREFIX) {
+            info!(%tenant.id, "deleting existing tenant");
+            client.delete_tenant(tenant.id).await.unwrap();
+        }
     }
 }
 
@@ -68,7 +72,7 @@ async fn test_tenants_and_users() {
     client
         .create_tenant(&TenantRequest {
             id: tenant_id_1,
-            name: "test tenant 1",
+            name: &format!("{TENANT_NAME_PREFIX} 1"),
             metadata: json!({
                 "tenant_number": 1,
             }),
@@ -78,21 +82,27 @@ async fn test_tenants_and_users() {
     client
         .create_tenant(&TenantRequest {
             id: tenant_id_2,
-            name: "test tenant 2",
+            name: &format!("{TENANT_NAME_PREFIX} 2"),
             metadata: json!(42),
         })
         .await
         .unwrap();
 
     // Verify tenant properties.
-    let mut tenants = client.list_tenants().await.unwrap();
+    let mut tenants: Vec<_> = client
+        .list_tenants()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.name.starts_with(TENANT_NAME_PREFIX))
+        .collect();
     // Sort tenants by name to match order. Default ordering is by tenant ID.
     tenants.sort_by(|a, b| a.name.cmp(&b.name));
     assert_eq!(tenants.len(), 2);
     assert_eq!(tenants[0].id, tenant_id_1);
     assert_eq!(tenants[1].id, tenant_id_2);
-    assert_eq!(tenants[0].name, "test tenant 1");
-    assert_eq!(tenants[1].name, "test tenant 2");
+    assert_eq!(tenants[0].name, format!("{TENANT_NAME_PREFIX} 1"));
+    assert_eq!(tenants[1].name, format!("{TENANT_NAME_PREFIX} 2"));
     assert_eq!(tenants[0].metadata, json!({"tenant_number": 1}));
     assert_eq!(tenants[1].metadata, json!(42));
     assert_eq!(tenants[0].deleted_at, None);
@@ -154,7 +164,7 @@ async fn test_tenants_and_users() {
             .try_collect()
             .await
             .unwrap();
-        assert_eq!(expected, actual);
+        assert!(expected.difference(&actual).collect::<Vec<_>>().is_empty());
     }
 
     // Ensure that the user list can be filtered to a single tenant.
@@ -178,9 +188,12 @@ async fn test_tenants_and_users() {
     {
         let users: Vec<_> = client
             .list_users(Default::default())
-            .try_collect()
+            .try_collect::<Vec<_>>()
             .await
-            .unwrap();
+            .unwrap()
+            .into_iter()
+            .filter(|u| u.email.starts_with("frontegg-test-"))
+            .collect();
         assert_eq!(users.len(), 0);
     }
 }


### PR DESCRIPTION
[As documented in the Frontegg API](https://docs.frontegg.com/reference/tenantcontrollerv1_gettenant).

I opted to not expose the fact that Frontegg returns an empty or single element list here. I'm open to bikeshedding the synthetic 404 error. I went with that because it felt more RESTful.