### PR TITLE
Derive Serialize/Deserialize for all API types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
-* Support getting a tenant by ID.
+* Add the `Client::get_tenant` method to get a tenant by ID.
+
+* Uniformly derive `Serialize` and `Deserialize` on all API types, even if the
+  type is not serialized or deserialized by `Client`. The idea is to allow
+  downstream users to serialize and deserialize these types for their own
+  purposes (e.g., to store them on disk).
 
 ## [0.2.0] - 2023-02-18
 

--- a/src/client/roles.rs
+++ b/src/client/roles.rs
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 /// A Frontegg role.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Role {
     /// The ID of the role.
@@ -42,7 +42,7 @@ pub struct Role {
 }
 
 /// A Frontegg permission.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Permission {
     /// The ID of the permission.

--- a/src/client/tenants.rs
+++ b/src/client/tenants.rs
@@ -25,7 +25,7 @@ use crate::{error, Client, Error};
 const TENANT_PATH: [&str; 4] = ["tenants", "resources", "tenants", "v1"];
 
 /// The subset of [`Tenant`] used in create requests.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TenantRequest<'a> {
     /// The ID of the tenant.
@@ -38,7 +38,7 @@ pub struct TenantRequest<'a> {
 }
 
 /// A Frontegg tenant.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Tenant {
     /// The ID of the tenant.
@@ -48,7 +48,7 @@ pub struct Tenant {
     pub name: String,
     /// Arbitrary metadata that is attached to the tenant.
     #[serde(default = "crate::serde::empty_json_object")]
-    #[serde(with = "crate::serde::nested_json")]
+    #[serde(deserialize_with = "crate::serde::nested_json::deserialize")]
     pub metadata: serde_json::Value,
     /// The time at which the tenant was created.
     #[serde(with = "time::serde::rfc3339")]

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -62,7 +62,7 @@ impl UserListConfig {
 }
 
 /// The subset of [`User`] used in create requests.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserRequest<'a> {
     /// The ID of the tenant to which the user will belong.
@@ -79,7 +79,7 @@ pub struct UserRequest<'a> {
 }
 
 /// The subset of a [`User`] returned by [`Client::create_user`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatedUser {
     /// The ID of the user.
@@ -90,7 +90,7 @@ pub struct CreatedUser {
     pub email: String,
     /// Arbitrary metadata that is attached to the user.
     #[serde(default = "crate::serde::empty_json_object")]
-    #[serde(with = "crate::serde::nested_json")]
+    #[serde(deserialize_with = "crate::serde::nested_json::deserialize")]
     pub metadata: serde_json::Value,
     /// The roles to which this user belongs.
     pub roles: Vec<Role>,
@@ -102,7 +102,7 @@ pub struct CreatedUser {
 }
 
 /// The subset of a [`User`] returned by a `frontegg.user.*` webhook event
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookUser {
     /// The ID of the user.
@@ -113,7 +113,7 @@ pub struct WebhookUser {
     pub email: String,
     /// Arbitrary metadata that is attached to the user.
     #[serde(default = "crate::serde::empty_json_object")]
-    #[serde(with = "crate::serde::nested_json")]
+    #[serde(deserialize_with = "crate::serde::nested_json::deserialize")]
     pub metadata: serde_json::Value,
     /// The roles to which this user belongs.
     pub roles: Vec<Role>,
@@ -151,7 +151,7 @@ pub struct WebhookUser {
 }
 
 /// A Frontegg user.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
     /// The ID of the user.
@@ -162,7 +162,7 @@ pub struct User {
     pub email: String,
     /// Arbitrary metadata that is attached to the user.
     #[serde(default = "crate::serde::empty_json_object")]
-    #[serde(with = "crate::serde::nested_json")]
+    #[serde(deserialize_with = "crate::serde::nested_json::deserialize")]
     pub metadata: serde_json::Value,
     /// The tenants to which this user belongs.
     pub tenants: Vec<TenantBinding>,
@@ -174,7 +174,7 @@ pub struct User {
 /// Binds a [`User`] to a [`Tenant`] for a `frontegg.user.*` webhook event
 ///
 /// [`Tenant`]: crate::client::tenant::Tenant
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookTenantBinding {
     /// The ID of the tenant.
@@ -186,7 +186,7 @@ pub struct WebhookTenantBinding {
 /// Binds a [`User`] to a [`Tenant`].
 ///
 /// [`Tenant`]: crate::client::tenant::Tenant
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TenantBinding {
     /// The ID of the tenant.


### PR DESCRIPTION
Even though we don't always serialize/deserialize all of these types, it's sometimes useful for downstream consumers to be able to.