### PR TITLE
use reqwest_retry to automatically retry failed requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         include:
           - build: macos
             os: macos-latest
-            rust: 1.65.0
+            rust: 1.68.2
           - build: ubuntu
             os: ubuntu-latest
-            rust: 1.65.0
+            rust: 1.68.2
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: 1.68.2
         default: true
         components: rustfmt
     - run: cargo fmt -- --check
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: 1.68.2
         default: true
         components: clippy
     - uses: actions-rs/clippy-check@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Automatically retry read-only HTTP requests.
+
 ## [0.3.0] - 2023-02-26
 
 * Add the `Client::get_tenant` method to get a tenant by ID.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["api-bindings", "web-programming"]
 keywords = ["frontegg", "front", "egg", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-frontegg"
 version = "0.3.0"
-rust-version = "1.65"
+rust-version = "1.68.2"
 edition = "2021"
 
 [dependencies]
@@ -17,6 +17,8 @@ async-stream = "0.3.3"
 futures-core = "0.3.25"
 once_cell = "1.16.0"
 reqwest = { version = "0.11.13", features = ["json"] }
+reqwest-middleware = "0.2.2"
+reqwest-retry = "0.2.2"
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
 time = { version = "0.3.17", features = ["serde", "serde-human-readable"] }
@@ -30,6 +32,7 @@ tokio = { version = "1.23.0", features = ["macros"] }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+wiremock = "0.5.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -173,7 +173,7 @@ pub struct User {
 
 /// Binds a [`User`] to a [`Tenant`] for a `frontegg.user.*` webhook event
 ///
-/// [`Tenant`]: crate::client::tenant::Tenant
+/// [`Tenant`]: crate::client::tenants::Tenant
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookTenantBinding {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,10 @@ use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use reqwest::Url;
+use reqwest_retry::policies::ExponentialBackoff;
+use reqwest_retry::RetryTransientMiddleware;
 
-use crate::Client;
+use crate::client::Client;
 
 pub static DEFAULT_VENDOR_ENDPOINT: Lazy<Url> = Lazy::new(|| {
     "https://api.frontegg.com"
@@ -37,27 +39,55 @@ pub struct ClientConfig {
 /// A builder for a [`Client`].
 pub struct ClientBuilder {
     vendor_endpoint: Url,
+    retry_policy: Option<ExponentialBackoff>,
 }
 
 impl Default for ClientBuilder {
     fn default() -> ClientBuilder {
         ClientBuilder {
             vendor_endpoint: DEFAULT_VENDOR_ENDPOINT.clone(),
+            retry_policy: Some(
+                ExponentialBackoff::builder()
+                    .retry_bounds(Duration::from_millis(100), Duration::from_secs(3))
+                    .build_with_max_retries(5),
+            ),
         }
     }
 }
 
 impl ClientBuilder {
+    /// Sets the policy for retrying failed read-only API calls.
+    ///
+    /// Note that the created [`Client`] will retry only read-only API calls,
+    /// like [`get_tenant`](Client::get_tenant), but not mutating API calls,
+    /// like [`create_user`](Client::create_user).
+    pub fn with_retry_policy(mut self, policy: ExponentialBackoff) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Sets the vendor endpoint.
+    pub fn with_vendor_endpoint(mut self, endpoint: Url) -> Self {
+        self.vendor_endpoint = endpoint;
+        self
+    }
+
     /// Creates a [`Client`] that incorporates the optional parameters
     /// configured on the builder and the specified required parameters.
     pub fn build(self, config: ClientConfig) -> Client {
-        let inner = reqwest::ClientBuilder::new()
+        let client = reqwest::ClientBuilder::new()
             .redirect(reqwest::redirect::Policy::none())
             .timeout(Duration::from_secs(60))
             .build()
             .unwrap();
         Client {
-            inner,
+            client_retryable: match self.retry_policy {
+                Some(policy) => reqwest_middleware::ClientBuilder::new(client.clone())
+                    .with(RetryTransientMiddleware::new_with_policy(policy))
+                    .build(),
+                None => reqwest_middleware::ClientBuilder::new(client.clone()).build(),
+            },
+            client_non_retryable: reqwest_middleware::ClientBuilder::new(client).build(),
             client_id: config.client_id,
             secret_key: config.secret_key,
             vendor_endpoint: self.vendor_endpoint,

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ use reqwest::StatusCode;
 #[derive(Debug)]
 pub enum Error {
     /// An error in the underlying transport.
-    Transport(reqwest::Error),
+    Transport(reqwest_middleware::Error),
     /// An error returned by the API.
     Api(ApiError),
 }
@@ -61,9 +61,15 @@ impl fmt::Display for ApiError {
 
 impl std::error::Error for ApiError {}
 
+impl From<reqwest_middleware::Error> for Error {
+    fn from(e: reqwest_middleware::Error) -> Error {
+        Error::Transport(e)
+    }
+}
+
 impl From<reqwest::Error> for Error {
     fn from(e: reqwest::Error) -> Error {
-        Error::Transport(e)
+        Error::Transport(reqwest_middleware::Error::from(e))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,7 @@
 use std::fmt;
 use std::iter;
 
-use reqwest::RequestBuilder;
+use reqwest_middleware::RequestBuilder;
 use uuid::Uuid;
 
 pub trait RequestBuilderExt {


### PR DESCRIPTION
supersedes https://github.com/MaterializeInc/rust-frontegg/pull/12

but non forked. 

attempts to fix https://github.com/MaterializeInc/rust-frontegg/issues/10

Adds retries via reqwest_retry / reqwest_middlware.

Caution!!!
I'm bad at rust
