### PR TITLE
Add Python bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
 
+env:
+  CARGO_TERM_COLOR: always
+
+defaults:
+  run:
+    shell: bash # necessary for windows
+
 jobs:
   test:
     name: test
@@ -21,39 +28,124 @@ jobs:
             os: ubuntu-latest
             rust: 1.68.2
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        default: true
-    - run: cargo test -- --test-threads=1
-      env:
-        FRONTEGG_CLIENT_ID: 50864121-dfcc-4847-aab5-d56a993cd696
-        FRONTEGG_SECRET_KEY: ${{ secrets.FRONTEGG_SECRET_KEY }}
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          default: true
+      - run: cargo test -- --test-threads=1
+        env:
+          FRONTEGG_CLIENT_ID: 50864121-dfcc-4847-aab5-d56a993cd696
+          FRONTEGG_SECRET_KEY: ${{ secrets.FRONTEGG_SECRET_KEY }}
 
   fmt:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.68.2
-        default: true
-        components: rustfmt
-    - run: cargo fmt -- --check
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.68.2
+          default: true
+          components: rustfmt
+      - run: cargo fmt -- --check
 
   clippy:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.68.2
-        default: true
-        components: clippy
-    - uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.68.2
+          default: true
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  build-python:
+    strategy:
+      fail-fast: false
+      matrix:
+        # a list of all the targets
+        include:
+          - TARGET: x86_64-unknown-linux-gnu
+            OS: ubuntu-latest
+          - TARGET: aarch64-unknown-linux-gnu
+            OS: ubuntu-latest
+          - TARGET: aarch64-apple-darwin
+            OS: macos-latest
+          - TARGET: x86_64-apple-darwin
+            OS: macos-latest
+          - TARGET: x86_64-pc-windows-msvc
+            OS: windows-latest
+    needs: clippy
+    runs-on: ${{ matrix.OS }}
+    env:
+      NAME: rust-cross-compile-example # change with the name of your project
+      TARGET: ${{ matrix.TARGET }}
+      OS: ${{ matrix.OS }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ./target
+          key: build-cargo-registry-${{matrix.TARGET}}
+      - name: List
+        run: find ./
+      - name: Install and configure dependencies
+        run: |
+          # dependencies are only needed on ubuntu as that's the only place where
+          # we make cross-compilation
+          if [[ $OS =~ ^ubuntu.*$ ]]; then
+            sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf
+          fi
+
+          # some additional configuration for cross-compilation on linux
+          cat >>~/.cargo/config <<EOF
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          [target.aarch64-unknown-linux-musl]
+          linker = "aarch64-linux-gnu-gcc"
+          [target.armv7-unknown-linux-gnueabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.armv7-unknown-linux-musleabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.arm-unknown-linux-gnueabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.arm-unknown-linux-musleabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          EOF
+      - name: Install rust target
+        run: rustup target add $TARGET
+      - name: Run build
+        run: cargo build --release --verbose --target $TARGET
+      - name: List target
+        run: find ./target
+      - name: Compress
+        run: |
+          mkdir -p ./artifacts
+          # windows is the only OS using a different convention for executable file name
+          if [[ $OS =~ ^windows.*$ ]]; then
+              EXEC=$NAME.exe
+          else
+              EXEC=$NAME
+          fi
+          if [[ $GITHUB_REF_TYPE =~ ^tag$ ]]; then
+            TAG=$GITHUB_REF_NAME
+          else
+            TAG=$GITHUB_SHA
+          fi
+          mv ./target/$TARGET/release/$EXEC ./$EXEC
+          tar -czf ./artifacts/$NAME-$TARGET-$TAG.tar.gz $EXEC
+      - name: Archive artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: result
+          path: |
+            ./artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+.DS_Store
+.venv
+.envrc
 /target
 /Cargo.lock
+**/__pycache__

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 
 [dependencies]
 async-stream = "0.3.3"
+futures = { version = "0.3.25", optional = true }
 futures-core = "0.3.25"
 once_cell = "1.16.0"
 reqwest = { version = "0.11.13", features = ["json"] }
@@ -24,8 +25,12 @@ serde_json = "1.0.91"
 time = { version = "0.3.17", features = ["serde", "serde-human-readable"] }
 tokio = { version = "1.23.0" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+pyo3 = { version = "0.19.2", optional = true, features = ["extension-module", "multiple-pymethods"] }
+pyo3-asyncio = { version = "0.19.0", optional = true, features = ["tokio-runtime"] }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
+frontegg = "0.6.0"
 futures = "0.3.25"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.23.0", features = ["macros"] }
@@ -37,3 +42,9 @@ wiremock = "0.5.19"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+python = ["dep:futures", "dep:pyo3", "dep:pyo3-asyncio"]
+
+[lib]
+crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ An async Rust API client for the [Frontegg] user management service.
 frontegg = "0.6.0"
 ```
 
+## features
+
+The "python" feature adds bindings to Python (using `pyo3`). To develop against these bindings, you will need the `maturin` build tool.
+
 **[View documentation.](https://docs.rs/frontegg/0.6.0)**
 
 [Frontegg]: https://frontegg.com
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "frontegg_api"
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+module-name = "frontegg_api"
+features = ["python"]
+# all-features = false
+compatibility = "manylinux2014"

--- a/src/client/roles.rs
+++ b/src/client/roles.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 /// A Frontegg role.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "python", pyo3::pyclass(frozen))]
 pub struct Role {
     /// The ID of the role.
     pub id: Uuid,
@@ -44,6 +45,7 @@ pub struct Role {
 /// A Frontegg permission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "python", pyo3::pyclass(frozen))]
 pub struct Permission {
     /// The ID of the permission.
     pub id: Uuid,

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,19 @@ impl ClientBuilder {
             secret_key: config.secret_key,
             vendor_endpoint: self.vendor_endpoint,
             auth: Default::default(),
+            #[cfg(feature = "python")]
+            rt: None,
         }
+    }
+
+    #[cfg(feature = "python")]
+    pub(crate) fn build_on_runtime(
+        self,
+        config: ClientConfig,
+        rt: tokio::runtime::Runtime,
+    ) -> Client {
+        let mut client = self.build(config);
+        client.rt = Some(rt);
+        client
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,23 @@ pub use client::users::{
 pub use client::Client;
 pub use config::{ClientBuilder, ClientConfig};
 pub use error::{ApiError, Error};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "python")] {
+        use pyo3::prelude::*;
+
+        pyo3::create_exception!(frontegg_api, NotFoundError, pyo3::exceptions::PyException, "Not found");
+
+        #[pymodule]
+        fn frontegg_api(py: Python, m: &PyModule) -> PyResult<()> {
+            m.add_class::<Client>()?;
+            m.add_class::<Permission>()?;
+            m.add_class::<Role>()?;
+            m.add_class::<Tenant>()?;
+            m.add_class::<User>()?;
+            m.add("NotFoundError", py.get_type::<NotFoundError>())?;
+            Ok(())
+        }
+
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,3 +50,128 @@ where
             .collect()
     }
 }
+
+#[cfg(feature = "python")]
+pub(crate) mod py {
+    use super::Uuid;
+    use pyo3::ToPyObject;
+    use std::collections::HashMap;
+    use std::convert::TryFrom;
+
+    pub(crate) fn json_to_object(
+        py: pyo3::Python,
+        val: &serde_json::Value,
+    ) -> pyo3::PyResult<pyo3::PyObject> {
+        match val {
+            serde_json::Value::Null => Ok(py.None()),
+            serde_json::Value::Bool(v) => {
+                let b = pyo3::types::PyBool::new(py, *v);
+                let o: pyo3::Py<pyo3::PyAny> = b.into();
+                Ok(o)
+            }
+            serde_json::Value::Number(v) => {
+                let n = if v.is_i64() {
+                    v.as_i64().to_object(py)
+                } else if v.is_f64() {
+                    v.as_f64().to_object(py)
+                } else {
+                    panic!("JSON value {v:?} not convertible to Python")
+                };
+                Ok(n)
+            }
+            serde_json::Value::String(v) => {
+                let s = pyo3::types::PyString::new(py, v);
+                let o: pyo3::Py<pyo3::PyAny> = s.into();
+                Ok(o)
+            }
+            serde_json::Value::Array(v) => {
+                let a = v.iter().map(|e| {
+                    json_to_object(py, e)
+                        .unwrap_or_else(|_| panic!("JSON element {e:?} not convertible to Python"))
+                });
+                let l = pyo3::types::PyList::new(py, a);
+                let o: pyo3::Py<pyo3::PyAny> = l.into();
+                Ok(o)
+            }
+            // TODO: is there a neater way to do this?
+            serde_json::Value::Object(o) => {
+                let d = pyo3::types::PyDict::new(py);
+                for (k, v) in o.iter() {
+                    d.set_item(k, json_to_object(py, v)?)?;
+                }
+                let o: pyo3::Py<pyo3::PyAny> = d.into();
+                Ok(o)
+            }
+        }
+    }
+
+    pub(crate) fn object_to_json(
+        py: pyo3::Python,
+        val: &pyo3::PyAny,
+    ) -> pyo3::PyResult<serde_json::Value> {
+        if val.eq(py.None())? {
+            Ok(serde_json::Value::Null)
+        } else if let Ok(s) = val.extract::<&str>() {
+            Ok(serde_json::Value::String(s.to_string()))
+        } else if let Ok(b) = val.extract::<bool>() {
+            Ok(serde_json::Value::Bool(b))
+        } else if let Ok(o) = val.extract::<HashMap<&str, &pyo3::PyAny>>() {
+            let elements = o
+                .iter()
+                .filter_map(|(k, v)| object_to_json(py, v).map(|j| (k.to_string(), j)).ok());
+            let mapping = serde_json::Map::from_iter(elements);
+            Ok(serde_json::Value::Object(mapping))
+        } else if let Ok(a) = val.extract::<Vec<&pyo3::PyAny>>() {
+            let contents = a
+                .iter()
+                .filter_map(|e| object_to_json(py, e).ok())
+                .collect();
+            Ok(serde_json::Value::Array(contents))
+        } else if let Ok(n) = val.extract::<f64>() {
+            Ok(serde_json::Value::Number(
+                serde_json::Number::from_f64(n).expect("Could not numberize"),
+            ))
+        } else {
+            Err(pyo3::exceptions::PyAssertionError::new_err("Can't JSONify"))
+        }
+    }
+
+    pub(crate) struct PyUuid(pub Uuid);
+
+    impl<'gil> TryFrom<&'gil pyo3::PyAny> for PyUuid {
+        type Error = pyo3::PyErr;
+
+        fn try_from(value: &'gil pyo3::PyAny) -> Result<Self, Self::Error> {
+            let py_string = if value.is_instance_of::<pyo3::types::PyString>() {
+                value
+            } else {
+                value.call_method0("__str__")?
+            };
+            let s: &str = py_string.extract()?;
+            let i = Uuid::parse_str(s).map_err(|_| {
+                pyo3::PyErr::from_value(
+                    pyo3::exceptions::PyValueError::new_err(format!("{s} is not a valid UUID"))
+                        .value(value.py()),
+                )
+            })?;
+            Ok(Self(i))
+        }
+    }
+
+    impl TryFrom<PyUuid> for pyo3::PyObject {
+        type Error = pyo3::PyErr;
+
+        fn try_from(value: PyUuid) -> Result<Self, Self::Error> {
+            pyo3::Python::with_gil(|py| {
+                let as_str = value
+                    .0
+                    .hyphenated()
+                    .encode_lower(&mut Uuid::encode_buffer())
+                    .to_string();
+                let args = (as_str,);
+                let uuid = pyo3::types::PyModule::import(py, "uuid")?;
+                Ok(uuid.getattr("UUID")?.call(args, None)?.into())
+            })
+        }
+    }
+}

--- a/tests/api.py
+++ b/tests/api.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+import os
+import datetime
+from unittest import SkipTest, TestCase, main
+import uuid
+
+import frontegg_api
+
+
+class TestTenantsAndUsers(TestCase):
+    """
+    Rough-and-ready replica of test_tenants_and_users in the Rust API tests;
+    driving the same functionality from both Rust and Python should show
+    fidelity of the Python bindings.
+    """
+
+    TENANT_NAME_PREFIX = "test tenant"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client = frontegg_api.Client(
+            os.environ["FRONTEGG_CLIENT_ID"], os.environ["FRONTEGG_SECRET_KEY"]
+        )
+
+        cls.tenant_ids = [uuid.uuid4(), uuid.uuid4()]
+        t1 = cls.client.create_tenant(
+            id=cls.tenant_ids[0],
+            name=f"{cls.TENANT_NAME_PREFIX} 1",
+            metadata={"tenant_number": 1},
+            creator_name="tenant 1",
+            creator_email="creator@tenant1.com",
+        )
+        t2 = cls.client.create_tenant(
+            id=cls.tenant_ids[1],
+            name=f"{cls.TENANT_NAME_PREFIX} 2",
+            metadata=42,
+        )
+        cls.tenants = [t1, t2]
+
+        cls.users = []
+        for tenant_idx, tenant_id in enumerate(cls.tenant_ids):
+            name = f"user-{tenant_idx}-00"
+            email = f"frontegg-test-{tenant_idx}-00@example.com"
+            user = cls.client.create_user(
+                tenant_id=tenant_id,
+                name=name,
+                email=email,
+                skip_invite_email=True,
+            )
+            cls.users.append(user)
+
+    def test_list_tenants(self):
+        all_ts = self.client.list_tenants()
+        test_tenants = [t for t in all_ts if t.name.startswith(self.TENANT_NAME_PREFIX)]
+        self.assertEqual(len(test_tenants), 2)
+
+    def test_create_tenant(self):
+        t_id = uuid.uuid4()
+        t = self.client.create_tenant(
+            id=t_id,
+            name=f"{self.TENANT_NAME_PREFIX} 3",
+            metadata={"tenant_number": 3},
+            creator_name="tenant 3",
+            creator_email="creator@tenant3.com",
+        )
+        self.tenant_ids.append(t.id)
+        self.tenants.append(t)
+        self.assertEqual(t.id, t_id)
+        self.assertEqual(t.name, f"{self.TENANT_NAME_PREFIX} 3")
+        self.assertEqual(t.metadata, {"tenant_number": 3})
+        self.assertEqual(t.creator_name, "tenant 3")
+        self.assertEqual(t.creator_email, "creator@tenant3.com")
+        self.assertEqual(t.deleted_at, None)
+
+    def test_get_tenant(self):
+        t = self.client.get_tenant(self.tenant_ids[1])
+        self.assertEqual(t.name, f"{self.TENANT_NAME_PREFIX} 2")
+        self.assertEqual(t.metadata, 42)
+        self.assertEqual(t.creator_name, None)
+        self.assertEqual(t.creator_email, None)
+
+    def test_delete_tenant(self):
+        self.client.delete_tenant(self.tenant_ids[2])
+        with self.assertRaises(frontegg_api.NotFoundError):
+            self.client.get_tenant(self.tenant_ids[2])
+
+    def test_tenant_metadata(self):
+        self.client.set_tenant_metadata(
+            self.tenant_ids[0],
+            {
+                "tenant_name": self.tenants[0].name,
+            },
+        )
+        tenant = self.client.get_tenant(self.tenants[0].id)
+        self.assertEqual(
+            tenant.metadata, {"tenant_name": tenant.name, "tenant_number": 1}
+        )
+
+        self.client.set_tenant_metadata(self.tenants[0].id, {"tenant_name": "set test"})
+        tenant = self.client.get_tenant(self.tenants[0].id)
+        self.assertEqual(
+            tenant.metadata, {"tenant_name": "set test", "tenant_number": 1}
+        )
+
+        self.client.delete_tenant_metadata(self.tenants[0].id, "tenant_name")
+        tenant = self.client.get_tenant(self.tenants[0].id)
+        self.assertEqual(tenant.metadata, {"tenant_number": 1})
+
+    def test_list_users(self):
+        all_users = self.client.list_users()
+        self.assertEqual(
+            len([u for u in all_users if u.email.startswith("frontegg-test-")]), 7
+        )
+        all_users_paginated = self.client.list_users(page_size=1)
+        self.assertEqual(len(all_users), len(all_users_paginated))
+        one_tenant_users = self.client.list_users(tenant_id=self.tenant_ids[0])
+        self.assertTrue(
+            all([u.email.startswith("frontegg-test-0") for u in one_tenant_users])
+        )
+        one_tenant_users_uuid = self.client.list_users(tenant_id=self.tenant_ids[0])
+        self.assertEqual(
+            [u.id for u in one_tenant_users], [u.id for u in one_tenant_users_uuid]
+        )
+
+    def test_get_user(self):
+        with self.assertRaises(ValueError):
+            self.client.get_user("foo")
+        with self.assertRaises(frontegg_api.NotFoundError):
+            self.client.get_user(uuid.uuid4())
+        known = self.client.get_user(self.users[0].id)
+        self.assertIsInstance(known.created_at, datetime.datetime)
+        self.assertIsInstance(known.id, uuid.UUID)
+        self.assertEqual(known.name, f"user-0-00")
+        self.assertEqual(known.email, "frontegg-test-0-00@example.com")
+        self.assertEqual(known.metadata, None)
+
+    def test_create_user(self):
+        for tenant_idx, tenant_id in enumerate(self.tenant_ids):
+            for user_idx in range(3):
+                name = f"user-{tenant_idx}-{user_idx}"
+                email = f"frontegg-test-{tenant_idx}-{user_idx}@example.com"
+                created_user = self.client.create_user(
+                    tenant_id=tenant_id,
+                    name=name,
+                    email=email,
+                    skip_invite_email=True,
+                )
+
+                self.assertEqual(created_user.name, name)
+                self.assertIsInstance(created_user.id, uuid.UUID)
+
+    def test_delete_user(self):
+        self.client.delete_user(self.users[-1].id)
+        with self.assertRaises(frontegg_api.NotFoundError):
+            self.client.get_user(self.users[-1].id)
+
+    def test_user_roles(self):
+        user = self.client.get_user(self.users[0].id)
+        self.assertGreater(len(user.tenants), 0)
+        binding_to_tenant_1 = [
+            t for t in user.tenants if t.tenant_id == self.tenants[0].id
+        ]
+        self.assertEqual(len(binding_to_tenant_1), 1)
+        self.assertEqual(binding_to_tenant_1[0].tenant_id, self.tenants[0].id)
+        self.assertEqual(binding_to_tenant_1[0].roles, [])
+        self.assertEqual(user.tenants[0].roles, [])
+
+    # def test_get_workspace_client_id(self) -> str:
+    #     raise SkipTest()
+
+    # def test_verify_user(self):
+    #     raise SkipTest()
+
+    # def test_create_api_token(self):
+    #    raise SkipTest()
+
+    @classmethod
+    def tearDownClass(cls):
+        for tenant in cls.client.list_tenants():
+            if tenant.name.startswith(cls.TENANT_NAME_PREFIX):
+                cls.client.delete_tenant(str(tenant.id))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a `python` feature exposing Python bindings to the Rust code, via `maturin`, `pyo3` and `pyo3-asyncio`. For maximal compatibility, the bindings are written against the "limited" Python API and target Python 3.7.

- A `pyproject.toml` specifies the building of the Python extension, and contributor documentation now references `maturin`
- All structs and their fields are exposed as Python objects
- Tenant and User methods are exposed as (sync) Python methods
- `tests/api.py` tests the Python API in similar ways to how the Rust API is currently tested