### PR TITLE
Update reqwest and other dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         include:
           - build: macos
             os: macos-latest
-            rust: 1.68.2
+            rust: 1.75.0
           - build: ubuntu
             os: ubuntu-latest
-            rust: 1.68.2
+            rust: 1.75.0
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.68.2
+        toolchain: 1.75.0
         default: true
         components: rustfmt
     - run: cargo fmt -- --check
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.68.2
+        toolchain: 1.75.0
         default: true
         components: clippy
     - uses: actions-rs/clippy-check@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+## [0.7.0] - 2024-02-07
+
+* Update reqwest to 0.12.12
+* Update reqwest-middleware to 0.4.0
+* Update reqwest-retry to 0.7.0
+
+
+
 ## [0.6.0] - 2023-08-31
 
 * Add `Tenant::creator_name`, `Tenant::creator_email`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,31 +8,31 @@ license = "Apache-2.0"
 categories = ["api-bindings", "web-programming"]
 keywords = ["frontegg", "front", "egg", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-frontegg"
-version = "0.6.0"
-rust-version = "1.68.2"
+version = "0.7.0"
+rust-version = "1.75.0"
 edition = "2021"
 
 [dependencies]
-async-stream = "0.3.3"
-futures-core = "0.3.25"
-once_cell = "1.16.0"
-reqwest = { version = "0.11.13", features = ["json"] }
-reqwest-middleware = "0.2.2"
-reqwest-retry = "0.2.2"
-serde = { version = "1.0.151", features = ["derive"] }
-serde_json = "1.0.91"
-time = { version = "0.3.17", features = ["serde", "serde-human-readable"] }
-tokio = { version = "1.23.0" }
-uuid = { version = "1.2.2", features = ["serde", "v4"] }
+async-stream = "0.3.6"
+futures-core = "0.3.31"
+once_cell = "1.20.3"
+reqwest = { version = "0.12.12", features = ["json"] }
+reqwest-middleware = "0.4.0"
+reqwest-retry = "0.7.0"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+time = { version = "0.3.37", features = ["serde", "serde-human-readable"] }
+tokio = { version = "1.38.1" }
+uuid = { version = "1.13.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
-futures = "0.3.25"
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tokio = { version = "1.23.0", features = ["macros"] }
-tokio-stream = "0.1.11"
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-wiremock = "0.5.19"
+futures = "0.3.31"
+test-log = { version = "0.2.14", default-features = false, features = ["trace"] }
+tokio = { version = "1.38.1", features = ["macros"] }
+tokio-stream = "0.1.15"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+wiremock = "0.6.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,8 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
+use crate::util::RequestBuilderExt;
+
 use crate::error::ApiError;
 use crate::{ClientBuilder, ClientConfig, Error};
 

--- a/src/client/tenants.rs
+++ b/src/client/tenants.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::RequestBuilderExt;
 use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::RequestBuilderExt;
 use async_stream::try_stream;
 use futures_core::stream::Stream;
 use reqwest::Method;
@@ -24,7 +25,7 @@ use crate::client::roles::{Permission, Role};
 use crate::client::Client;
 use crate::error::Error;
 use crate::serde::{Empty, Paginated};
-use crate::util::{RequestBuilderExt, StrIteratorExt};
+use crate::util::StrIteratorExt;
 
 const USER_PATH: [&str; 4] = ["identity", "resources", "users", "v1"];
 const VENDOR_USER_PATH: [&str; 5] = ["identity", "resources", "vendor-only", "users", "v1"];


### PR DESCRIPTION
This updates reqwest and other crates, primariliy to update a dependency on rust-idna to support more secure versions >1.0.0.

Some small refactoring of request building was necessary to support breaking changes in the reqwest API.