### PR TITLE
Upgrade to reqwest 0.13; default to rustls + aws-lc-rs (0.9.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         include:
           - build: macos
             os: macos-latest
-            rust: 1.86.0
+            rust: 1.88.0
           - build: ubuntu
             os: ubuntu-latest
-            rust: 1.86.0
+            rust: 1.88.0
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.86.0
+        toolchain: 1.88.0
         components: rustfmt
     - run: cargo fmt -- --check
 
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.86.0
+        toolchain: 1.88.0
         components: clippy
     - uses: actions-rs/clippy-check@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Default the TLS backend to rustls with the aws-lc-rs provider, which links no
+  system OpenSSL. The `native-tls` feature is available for consumers that
+  prefer the system TLS stack.
+* Update reqwest to 0.13, reqwest-middleware to 0.5, and reqwest-retry to 0.9.
+* Raise the minimum supported Rust version to 1.88.0.
+
 ## [0.8.0] - 2025-05-28
 
 * Update rust 1.86.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,22 +8,30 @@ license = "Apache-2.0"
 categories = ["api-bindings", "web-programming"]
 keywords = ["frontegg", "front", "egg", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-frontegg"
-version = "0.7.0"
-rust-version = "1.81.0"
+version = "0.8.0"
+rust-version = "1.88.0"
 edition = "2021"
 
 [dependencies]
 async-stream = "0.3.6"
 futures-core = "0.3.31"
 once_cell = "1.20.3"
-reqwest = { version = "0.12.12", features = ["json"] }
-reqwest-middleware = "0.4.0"
-reqwest-retry = "0.7.0"
+reqwest = { version = "0.13.1", default-features = false, features = ["json", "charset", "http2", "system-proxy"] }
+reqwest-middleware = { version = "0.5", features = ["query"] }
+reqwest-retry = "0.9"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 time = { version = "0.3.37", features = ["serde", "serde-human-readable"] }
 tokio = { version = "1.38.1" }
 uuid = { version = "1.13.1", features = ["serde", "v4"] }
+
+# Selects reqwest's TLS backend. The default rustls-tls links no system OpenSSL
+# (aws-lc-rs provider), which keeps static musl builds simple; native-tls is
+# available for consumers that prefer the system TLS stack.
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls"]
 
 [dev-dependencies]
 futures = "0.3.31"


### PR DESCRIPTION
## Why

`reqwest` was pulled with default features → **native-tls** → links system **OpenSSL**. That broke the connector build when `openssl-sys 0.9.116` dropped support for the Lambda base image's OpenSSL 1.0.2, and blocks static musl builds entirely.

reqwest **0.13** makes **rustls + aws-lc-rs** its default TLS stack, so this adopts it.

## Changes

- reqwest `0.12 → 0.13`, reqwest-middleware `0.4 → 0.5` (enable the now-gated `query` feature), reqwest-retry `0.7 → 0.9`.
- TLS-backend feature toggle, **defaulting to `rustls-tls`** (aws-lc-rs, no system OpenSSL). `native-tls` remains available.
- CI toolchain + `rust-version` → **1.88.0**: the deps' real MSRV (`time@0.3.47` needs it) and CI has no lockfile, so it resolves to latest. This was already failing on `main`.
- CHANGELOG `[Unreleased]` entry for the above.

## Releasing (cargo-release)

This is a breaking change (reqwest/reqwest-middleware are in the public API via `Error` and `RequestBuilderExt`) → **0.9.0**.

`Cargo.toml` is set to the last *published* version (**0.8.0**) rather than 0.9.0, so a maintainer just runs **`cargo release minor`** to cut 0.9.0 (date the CHANGELOG, update README, tag `v0.9.0`, publish). This also **realigns `main`**, whose version had drifted to `0.7.0` while 0.8.0 was published from an unmerged release branch — please ensure the release commit lands on `main` this time.

## Verified

- Builds on both the default (rustls/aws-lc-rs) and `native-tls` feature paths.
- Default dependency tree contains **aws-lc-rs** and **no openssl/native-tls**.
- CI (real amd64/macOS, live Frontegg API) — see checks.

## Note

reqwest 0.13's rustls uses `rustls-platform-verifier` (OS trust store); the al2023 Lambda runtime ships `ca-certificates`, so cert verification works without bundling roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)